### PR TITLE
feat(franchise) - expand franchise slot and base on market value

### DIFF
--- a/team/free-agents.md
+++ b/team/free-agents.md
@@ -20,12 +20,13 @@ After championship week all players at the end of their contract are declared fr
 
 ### Franchise Tag
 
-At the end of the season when player contracts are expiring, a team has the option to apply a “Franchise Tag” on **1 departing player** with the following rules:
+At the end of the season when player contracts are expiring, a team has the option to apply a “Franchise Tag” on **2 departing players** with the following rules:
 
-* The owner can extend the player’s contract for 1-year at salary of 15% over either their market value or what you paid them last year (whichever is higher).
-* The second year a franchise tag is applied to a player, the rate increases to 30%.
+* The owner can extend the player’s contract for 1-year at salary of 5% over either their market value or what you paid them last year (whichever is higher).
+* The second year a franchise tag is applied to a player, the rate increases to 15%.
 * The franchse price has a $50 minimum.
 * A player cannot be franchised 3 years in a row.
+* A player's franchise streak follows him through trades.
 * A franchise tag must be declared prior to the *pre-draft roster lock*.
 
 


### PR DESCRIPTION
As a means to incentivize holding onto players with expiring contracts, expand number of keepable players and lower the price to keep a player.

Closes #60