### PR TITLE
fix(offseason-bidding): Handle case where a bid loses to a subsequent…

### DIFF
--- a/team/free-agents.md
+++ b/team/free-agents.md
@@ -50,6 +50,8 @@ When two matching bids are submitted, the bid submitted on an earlier calendar d
 
 Owners may bid over their cap or roster size limit, but if a winning bid puts a team over cap space or roster limit, the owner must terminate previously existing contracts until the team once again is within roster and cap limits immediately with same 24 hours warning and 48 hour fine indicated in "In-Season Free Agents" section above. New players cannot be added and bids  cannot be won until the team us within roster and cap space limits. Also, a winning bid that puts an owner over cap/roster limits cannot be dropped until the team is within roster and cap limits.
 
+If a bid loses to a pending bid and the pending bid is cancelled, any bid that lost due to the cancelled bid becomes eligible to win the player based on the established winning criteria from above (i.e. bid must be the highest bid for 3 consecutive midnights). The team winning a player this way has a choice to take the player or not. If not, then the bidding process resumes to the next applicable bid based on this criteria or the player remains a free agent.
+
 ### Timeline for acquiring Free Agents
 
 | When | What |

--- a/team/free-agents.md
+++ b/team/free-agents.md
@@ -50,7 +50,7 @@ When two matching bids are submitted, the bid submitted on an earlier calendar d
 
 Owners may bid over their cap or roster size limit, but if a winning bid puts a team over cap space or roster limit, the owner must terminate previously existing contracts until the team once again is within roster and cap limits immediately with same 24 hours warning and 48 hour fine indicated in "In-Season Free Agents" section above. New players cannot be added and bids  cannot be won until the team us within roster and cap space limits. Also, a winning bid that puts an owner over cap/roster limits cannot be dropped until the team is within roster and cap limits.
 
-If a bid loses to a pending bid and the pending bid is cancelled, any bid that lost due to the cancelled bid becomes eligible to win the player based on the established winning criteria from above (i.e. bid must be the highest bid for 3 consecutive midnights). The team winning a player this way has a choice to take the player or not. If not, then the bidding process resumes to the next applicable bid based on this criteria or the player remains a free agent.
+If a bid loses to a pending bid and the pending bid is cancelled, any bid that lost due to the cancelled bid becomes eligible to win the player based on the established winning criteria from above (i.e. bid must be the highest bid for 3 consecutive midnights). The team winning a player this way has a choice to take the player or not. If the team declines to take the player, their bid is deemed "cancelled" and the bidding process resumes to the next applicable bid based on the criteria above.
 
 ### Timeline for acquiring Free Agents
 


### PR DESCRIPTION
…ly cancelled bid

Fixes the scenario where a bid loses to a pending bid where the pending bid is eventually cancelled before the player is won. In the spirit of the bidding process, once the higher bid is cancelled, if the original losing bid was the highest active bid for 3 consecutive midnights, the team should win the player.

Fixes #52