### PR TITLE
fix(trades): add cap on cap space received

### DIFF
--- a/league/trades.md
+++ b/league/trades.md
@@ -3,7 +3,7 @@
 1. Trade Deadline: After Week 8 - Last day to declare a trade is 12:00 PM PST the Wednesday before Week 9.
 2. Trades can be made at any time from the end of championship week until the next season’s trade deadline (after week 8).
 3. Draft picks can be traded up to **1 season** in advance. For example, picks in the 2012 rookie draft become available after championship week of 2010.
-4. Trades details must be declared in a post in #trades channel in Slack once both parties have come to agreement.
+4. Trades details must be declared in a post in #trade-announcements channel in Slack once both parties have come to agreement.
 5. Trades can be executed immediately upon mutual acceptance of terms.
 
 ## Tradable Commodities
@@ -13,5 +13,6 @@ The following resources can be included in trades:
 * Active Contracts.
 * Practice Squad Contracts.
 * Draft picks for the next rookie draft.
-* Cap space for the **current season.**
+* Cap space for the **current season**
+  * A team may not have more than $150 of active cap space coming from trades at any time. As trades execute sequentially, even if another trade is going to take place that lowers the team under this limit, the first trade is unable to execute if the team would be over this limit. If it is possible to exercise a multi-team trade (3 or more teams involved) that executes all at once and teams remain under this limit, then those trades are allowed.
 * Gum


### PR DESCRIPTION
As a means to curb fire sale trades, apply a maximum amount of "cap space received" that can apply to the overall cap space a team can have.

Closes #60