### PR TITLE
fix(trades): clarification on unexecuted trades

### DIFF
--- a/league/trades.md
+++ b/league/trades.md
@@ -1,10 +1,11 @@
 # Trades
 
-1. Trade Deadline: After Week 8 - Last day to declare a trade is 12:00 PM PST the Wednesday before Week 9.
+1. Trade Deadline: After Week 8 - Last day to declare a trade is 12:00 PM PST the Wednesday before Week 9. 
 2. Trades can be made at any time from the end of championship week until the next season’s trade deadline (after week 8).
 3. Draft picks can be traded up to **1 season** in advance. For example, picks in the 2012 rookie draft become available after championship week of 2010.
 4. Trades details must be declared in a post in #trades channel in Slack once both parties have come to agreement.
 5. Trades can be executed immediately upon mutual acceptance of terms.
+6. Trades must be executed on Sleeper prior to the trade deadline on Sleeper. Trades that are announced but not executed prior to the trade deadline are void. 
 
 ## Tradable Commodities
 


### PR DESCRIPTION
Clarified that trades must not just be announced by the trade deadline, but should be executed in Sleeper.

Closes #85